### PR TITLE
[#119] Change CustomUserDetailsService Logic for Member Status

### DIFF
--- a/module-core/src/main/java/com/woomoolmarket/domain/member/repository/MemberRepository.java
+++ b/module-core/src/main/java/com/woomoolmarket/domain/member/repository/MemberRepository.java
@@ -2,13 +2,8 @@ package com.woomoolmarket.domain.member.repository;
 
 import com.woomoolmarket.common.enumeration.Status;
 import com.woomoolmarket.domain.member.entity.Member;
-import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 
@@ -16,9 +11,7 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
 
     Optional<Member> findByEmail(String email);
 
-    Optional<Member> findByPhone(String phone);
-
-    Optional<Member> findByNickname(String nickname);
+    Optional<Member> findByEmailAndStatus(String email, Status status);
 
     Optional<Member> findByIdAndStatus(Long id, Status status);
 

--- a/module-core/src/main/java/com/woomoolmarket/security/service/CustomUserDetailsService.java
+++ b/module-core/src/main/java/com/woomoolmarket/security/service/CustomUserDetailsService.java
@@ -1,5 +1,6 @@
 package com.woomoolmarket.security.service;
 
+import com.woomoolmarket.common.enumeration.Status;
 import com.woomoolmarket.common.util.ExceptionUtil;
 import com.woomoolmarket.domain.member.entity.Member;
 import com.woomoolmarket.domain.member.repository.MemberRepository;
@@ -24,9 +25,9 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) {
-        return memberRepository.findByEmail(email)
+        return memberRepository.findByEmailAndStatus(email, Status.ACTIVE)
             .map(this::createUserDetails)
-            .orElseThrow(() -> new UsernameNotFoundException(email + ExceptionUtil.MEMBER_NOT_FOUND));
+            .orElseThrow(() -> new UsernameNotFoundException(ExceptionUtil.MEMBER_NOT_FOUND));
     }
 
     private UserPrincipal createUserDetails(Member member) {

--- a/module-service/src/test/java/com/woomoolmarket/service/member/mapper/MemberResponseMapperTest.java
+++ b/module-service/src/test/java/com/woomoolmarket/service/member/mapper/MemberResponseMapperTest.java
@@ -38,7 +38,7 @@ class MemberResponseMapperTest {
     @Test
     @DisplayName("createdDate 받아온다")
     void memberMapperTest() {
-        Member findResult = memberRepository.findByNickname("panda").get();
+        Member findResult = memberRepository.findByEmail("panda@gmail.com").get();
         LocalDateTime createdDate = findResult.getCreatedDateTime();
         MemberResponse memberResponse = memberResponseMapper.toDto(findResult);
         assertThat(createdDate).isEqualTo(memberResponse.getCreatedDateTime());


### PR DESCRIPTION
활성 상태의 회원만 로그인 가능하도록 CustomUserDetailsService의 로직 변경
findByEmail -> findByEmailAndStatus
close #119